### PR TITLE
Enhancements for PMPro Signup Shortcode Add-on

### DIFF
--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -142,9 +142,9 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 		'short' => NULL,
 		'submit_button' => __("Sign Up Now", 'pmprosus'),
 		'title' => NULL,
+		'custom_fields' => true,
 	), $atts));
 	
-		
 	// set title
 	if($title === "1" || $title === "true" || $title === "yes")
 		$title_display = true;
@@ -171,7 +171,12 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 		$short = "emailonly";
 	else
 		$short = false;
+
+	//turn 0's into falses
+	if( $custom_fields === "0" || $custom_fields === "false" || $custom_fields === "no")
+		$custom_fields = false;
 		
+
 	global $current_user, $membership_levels, $pmpro_pages;	
 	
 	ob_start();
@@ -208,13 +213,13 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 				else
 				{
 					?>
-					<?php if( $short !== 'emailonly') { ?>
+					<?php if( $short !== 'emailonly' ) { ?>
 					<div>
 						<label for="username"><?php _e('Username', 'pmprosus');?></label>
 						<input id="username" name="username" type="text" class="input" size="30" value="" />
 					</div>
 					<?php } ?>
-					<?php do_action("pmpro_checkout_after_username");?>
+					<?php if($custom_fields){ do_action("pmpro_checkout_after_username"); }?>
 					<?php if( $short !== 'emailonly') { ?>
 					<div>
 						<label for="password"><?php _e('Password', 'pmprosus');?></label>
@@ -229,7 +234,7 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 							<input id="password2" name="password2" type="password" class="input" size="30" value="" />
 						</div>
 					<?php } ?>
-					<?php do_action("pmpro_checkout_after_password");?>
+					<?php if($custom_fields){ do_action("pmpro_checkout_after_password"); }?>
 					<div>
 						<label for="bemail"><?php _e('E-mail Address', 'pmprosus');?></label>
 						<input id="bemail" name="bemail" type="email" class="input" size="30" value="" />
@@ -279,13 +284,16 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 					<input type="submit" class="pmpro_btn pmpro_btn-submit-checkout" value="<?php echo $submit_button; ?>" />
 				</span>
 			</div>
+			<?php do_action( 'pmpross-after-submit' ); ?>
 			<?php if(!empty($login) && empty($current_user->ID)) { ?>
 			<div style="text-align:center;">
 				<a href="<?php echo wp_login_url(get_permalink()); ?>"><?php _e('Log In','pmpro'); ?></a>
 			</div>
 			<?php } ?>
 		</form>
-		<?php } ?>
+		<?php } 
+		do_action( 'pmpross-after-form' );
+		?>
 	<?php
 	$temp_content = ob_get_contents();
 	ob_end_clean();


### PR DESCRIPTION
* Enhancement - added custom_field attribute to show/hide custom fields
added by Register Helper. (Accepts boolean. Default true). Fields only
show if added to ‘after_username’ or ‘after_password’ (Other
checkoutboxes do not show up on signup form).

* Enhancement - added in a hook for users to easily output text or any
content between the signup and login button. (pmpross-after-submit)

*Enchancement -  added in a hook for users to easily output text or any
content after the signup form. (pmpross-after-form)