### PR TITLE
ENHANCEMENT: Action checkout_after_user_fields

### DIFF
--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -273,6 +273,7 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 					<?php
 				}
 			?>
+			<?php do_action('pmpro_checkout_after_user_fields'); ?>
 			<div>
 				<span id="pmpro_submit_span" >
 					<input type="hidden" name="submit-checkout" value="1" />


### PR DESCRIPTION
If the user is logged in, there's no way to add visible custom/RH fields to the shortcode form