### PR TITLE
Password not generating fix

### DIFF
--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -37,7 +37,7 @@ function pmprosus_skip_username_password()
 		$_GET['username'] = $_GET['bemail'];
 
 	//autogenerate password if no field is present
-	if(!empty($_REQUEST['bemail']) && !isset($_REQUEST['password']) && ( !isset( $current_user ) || $current_user->ID === 0 ) ) {
+	if(!empty($_REQUEST['bemail']) && !isset($_REQUEST['password']) && ! is_user_logged_in() ) {
 
 		//genreate password
 		$_REQUEST['password'] = wp_generate_password( 12, true, false );

--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -37,10 +37,10 @@ function pmprosus_skip_username_password()
 		$_GET['username'] = $_GET['bemail'];
 
 	//autogenerate password if no field is present
-	if(!empty($_REQUEST['bemail']) && !isset($_REQUEST['password'])&& !isset($current_user))
-	{
+	if(!empty($_REQUEST['bemail']) && !isset($_REQUEST['password']) && ( !isset( $current_user ) || $current_user->ID === 0 ) ) {
+
 		//genreate password
-		$_REQUEST['password'] = pmpro_getDiscountCode() . pmpro_getDiscountCode();	//using two random discount codes
+		$_REQUEST['password'] = wp_generate_password( 12, true, false );
 		$_REQUEST['password2'] = $_REQUEST['password'];
 
 		//set flag so we add the password to the confirmation email later


### PR DESCRIPTION
* Bug Fix: Passwords not generating due to $current_user being set even when empty. Added additional check to the password generation conditional.

* Enhancement: Use wp_generate_password instead of 2 random discount codes.