### PR TITLE
Format the username when the emailonly field is enabled

### DIFF
--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -28,7 +28,7 @@ function pmprosus_skip_username_password()
 
 	//copy email to username if no username field is present
 	if(!empty($_REQUEST['bemail']) && !isset($_REQUEST['username']))
-		$_REQUEST['username'] = $_REQUEST['bemail'];
+		$_REQUEST['username'] = function_exists( 'pmpro_generateUsername' ) ? pmpro_generateUsername( $_REQUEST['bemail'] ) : $_REQUEST['bemail'];
 
 	if(!empty($_POST['bemail']) && !isset($_POST['username']))
 		$_POST['username'] = $_POST['bemail'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-signup-shortcode/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-signup-shortcode/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Resolves #12

Reformat the email address when using it as the username to remov special characters. 

### How to test the changes in this Pull Request:

1. Use the shortode or similar [pmpro_signup submit_button="Unlock this Post Now!" level="4" login="1" redirect="referrer" short="emailonly"]  whereby the 'short' attr is set to emailonly
2. Enter in an email address and checkout/signup
3. The email address will be formatted without the @ and . symbols in the username. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Formats the email address when using it as an username and removes the @ and . symbols