### PR TITLE
Fixes User Fields Issues

### DIFF
--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -386,6 +386,34 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 					} ?>
 
 					<?php if( !empty( $custom_fields ) ) { do_action( 'pmpro_signup_form_before_submit' ); } ?>
+					
+					<?php 
+
+					if( ! empty( $custom_fields ) ) {
+						//Adds support for User Fields
+						global $pmpro_user_fields;
+						foreach( $pmpro_user_fields as $group ) {
+							foreach( $group as $field ) {
+								if ( ! pmpro_is_field( $field ) ) {
+									continue;
+								}
+								
+								if ( ! pmpro_check_field_for_level( $field ) ) {
+									continue;
+								}
+																	
+								if( ! isset( $field->profile ) || $field->profile !== 'only' && $field->profile !== 'only_admin' ) {
+									if ( ! empty( $field->required ) ) {
+										$field->showrequired = 'label';
+									} else {
+										$field->showrequired = '';
+									}
+									$field->displayAtCheckout();
+								}									
+							}
+						}
+					}
+					?>
 
 					<div class="pmpro_submit">
 						<span id="pmpro_submit_span">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-signup-shortcode/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-signup-shortcode/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds support for User Fields on the Signup Shortcode Form. 

Also fixes the issue of required fields not showing the required asterisk. 

Resolves #34
Resolves #38
Resolves #43 

![image](https://user-images.githubusercontent.com/8989542/210530700-23e3bdea-ab86-4e5c-bbcd-baef0a62b2fb.png)


Something to consider might be to allow the user to add the group name in the shortcode attribute so that only a specific group of fields are shown on the form. (custom_fields='More Information')

### How to test the changes in this Pull Request:

1. Create a set of fields in the User Fields section in PMPro
2. Set the custom_fields attribute in the Signup Shortcode to true
3. Those fields will show up on the signup form

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Added support for User Fields. Fixed a bug where the required asterisk did not show when required. 