### PR TITLE
Show/Hide the Confirm Email and Password fields

### DIFF
--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -169,6 +169,8 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 		'submit_button' => __("Sign Up Now", 'pmprosus'),
 		'title' => NULL,
 		'custom_fields' => true,
+		'confirm_email' => true,
+		'confirm_password' => true
 	), $atts));
 
 	// If there is a current level in global, save it to a backup variable.
@@ -214,6 +216,14 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 	//check which form format is specified
 	if( ! empty( $hidelabels ) ) {
 		$hidelabels = true;
+	}
+
+	if( $confirm_email === "0" || $confirm_email === "false" || $confirm_email === "no" ){
+		$confirm_email = false;
+	}
+
+	if( $confirm_password === "0" || $confirm_password === "false" || $confirm_password === "no" ){
+		$confirm_password = false;
 	}
 
 	//turn 0's into falses
@@ -315,7 +325,7 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 							</div>
 						<?php } ?>
 
-						<?php if( ! empty( $short ) ) { ?>
+						<?php if( ! empty( $short ) || ! $confirm_password ) { ?>
 							<input type="hidden" name="password2_copy" value="1" />
 						<?php } else { ?>
 							<div class="pmpro_checkout-field pmpro_checkout-field-password2">
@@ -331,7 +341,7 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 							<input id="bemail" name="bemail" type="email" class="input" size="30" value="<?php echo esc_attr( $bemail ); ?>" <?php if( ! empty( $hidelabels ) ) { ?> placeholder="<?php _e('E-mail Address', 'pmprosus');?>"<?php } ?> />
 						</div>
 
-						<?php if( ! empty( $short ) ) { ?>
+						<?php if( ! empty( $short ) || ! $confirm_email ) { ?>
 							<input type="hidden" name="bconfirmemail_copy" value="1" />
 						<?php } else { ?>
 							<div class="pmpro_checkout-field pmpro_checkout-field-bconfirmemail">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-signup-shortcode/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-signup-shortcode/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Introduces two new attributes to the shortcode. 

confirm_email: default true. false hides the Confirm Email field when not using the short attribute. 
confirm_password: default true. false hides the Confirm Pasword field when not using the short attribute. 

Resolves #17


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

You can now show/hide the Confirm Email and Confirm Password fields