### PR TITLE
Fixes issue of duplicate custom fields

### DIFF
--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -416,8 +416,11 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 					<?php if( !empty( $custom_fields ) ) { do_action( 'pmpro_signup_form_before_submit' ); } ?>
 					
 					<?php 
-
-					if( ! empty( $custom_fields ) ) {
+					/**
+					 * Adding in has_action ensures that the when using the pmpro_signup_form_before_submit hook
+					 * that we don't show duplicate fields below.
+					**/
+					if( ! empty( $custom_fields ) && ! has_action( 'pmpro_signup_form_before_submit' ) ) {
 						//Adds support for User Fields
 						global $pmpro_user_fields;
 						foreach( $pmpro_user_fields as $group ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-signup-shortcode/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-signup-shortcode/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Some users had enabled custom fields in the attributes and then hooked into the pmpro_signup_form_before_submit action to add custom fields. 

This results in duplicate fields if the original code isn't adjusted. 

This PR prevents the duplicate from running by not running the code we use to get all custom fields, and allow the action/hook to show the content instead. 


### How to test the changes in this Pull Request:

1. Register custom fields and add them to the pmpro_signup_form_before_submit hook
```
add_action( 'init', 'my_pmpro_add_user_fields' );
add_action( 'pmpro_signup_form_before_submit', 'pmpro_checkout_boxes_fields' );
```
2. Only one set of fields should show instead of duplicates.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixes the issue of duplicate custom fields showing on the sign up form.