### PR TITLE
Fixes reCAPTCHA not showing on signup form

### DIFF
--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -259,7 +259,7 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 	add_filter( 'pmpro_is_checkout', '__return_true' );
 
 	// load recaptcha if needed
-	if ( ! function_exists( 'pmpro_recaptcha_get_html' ) ) {
+	if ( function_exists( 'pmpro_recaptcha_get_html' ) ) {
 		pmpro_init_recaptcha();
 	}
 
@@ -383,16 +383,8 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 							<label for="fullname"><?php esc_html_e('Full Name', 'pmpro-signup-shortcode');?></label>
 							<input id="fullname" name="fullname" type="text" class="input" size="30" value="" /> <strong><?php esc_html_e('LEAVE THIS BLANK', 'pmpro-signup-shortcode');?></strong>
 						</div>
-
-						<?php
-							global $recaptcha, $recaptcha_publickey;
-							if( $recaptcha == 2 || ( ! empty( $level ) && $recaptcha == 1 && pmpro_isLevelFree( pmpro_getLevel( $level ) ) ) ) { ?>
-								<div class="pmpro_checkout-field pmpro_captcha">
-									<?php echo pmpro_recaptcha_get_html( $recaptcha_publickey, NULL, true ); ?>
-								</div> <!-- end pmpro_captcha -->
-							<?php } ?>
-
-					<?php } ?>
+	
+					<?php } ?>					
 
 					<?php do_action('pmpro_checkout_after_user_fields'); ?>
 
@@ -442,6 +434,14 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 						}
 					}
 					?>
+
+					<?php
+					$recaptcha = pmpro_getOption("recaptcha");
+					if ( $recaptcha == 2 || $recaptcha == 1 ) { ?>
+						<div class="pmpro_checkout-field pmpro_captcha">
+							<?php echo pmpro_recaptcha_get_html( ); ?>
+						</div> <!-- end pmpro_captcha -->
+					<?php } ?>
 
 					<div class="pmpro_submit">
 						<span id="pmpro_submit_span">

--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -383,8 +383,7 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 							<label for="fullname"><?php esc_html_e('Full Name', 'pmpro-signup-shortcode');?></label>
 							<input id="fullname" name="fullname" type="text" class="input" size="30" value="" /> <strong><?php esc_html_e('LEAVE THIS BLANK', 'pmpro-signup-shortcode');?></strong>
 						</div>
-	
-					<?php } ?>					
+						<?php } ?>					
 
 					<?php do_action('pmpro_checkout_after_user_fields'); ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-signup-shortcode/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-signup-shortcode/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Uses the 'new way' of how reCAPTCHA is displayed and used since the refactor

### How to test the changes in this Pull Request:

1. Add the signup shortcode to a page
2. Ensure that recaptcha is enabled and visible on the signup page (or invisible on the right)
3. Submit the form, no errors should be thrown

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
