### PR TITLE
Fix User Fields Not Showing When Restricted To Certain Levels

### DIFF
--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -201,7 +201,7 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 	}
 
 	//the default checkout boxes location is loaded only if custom_fields is specifically "1" or "true"
-	if( $custom_fields === "1" || $custom_fields === "true" ) {
+	if ( $custom_fields === "1" || $custom_fields === "true" || isset( $custom_fields ) ) {
 		$checkout_boxes = true;
 
 		// Set the level for this signup shortcode so level-specific checkout fields appear.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-signup-shortcode/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-signup-shortcode/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes #54 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX: Fixed case where the user fields for a specific level ID would not show on Signup Shortcode form.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
