### PR TITLE
Resolve PMPro_Field::displayAtCheckout is deprecated warnings

### DIFF
--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -411,36 +411,15 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 											// Loop through all the field groups.
 											$field_groups = PMPro_Field_Group::get_all();
 											foreach ( $field_groups as $field_group ) {
-												// Get the fields to display.
-												$fields_to_display = $field_group->get_fields_to_display(
+												$field_group->display(
 													array(
+														'markup' => 'div',
+														'show_group_label' => false,
 														'scope' => 'checkout',
+														'prefill_from_request' => true,
+														'show_required' => true,
 													)
 												);
-
-												if ( empty( $fields_to_display ) ) {
-													continue;
-												}
-
-												foreach ( $fields_to_display as $field ) {
-													// Display the field label, if it should be shown.
-													if ( ! empty( $field->showmainlabel ) ) { ?>
-														<label for="<?php echo esc_attr( $field->name ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
-															<?php echo wp_kses_post( $field->label ); ?>
-															<?php
-															// Show an asterisk if the field is required.
-															if ( ! empty( $field->required ) && ! empty( $field->showrequired ) ) {
-																?>
-																<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"><abbr title="<?php echo esc_attr__( 'Required Field', 'pmpro-signup-shortcode' ); ?>">*</abbr></span>
-																<?php
-															}
-															?>
-														</label>															
-														<?php
-													}
-													// Display the field.
-													$field->display();
-												}
 											}
 										} else {
 											// Legacy support for displaying User Fields on PMPro < 3.4.

--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -406,25 +406,45 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 
 								<?php
 									if( ! empty( $custom_fields ) ) {
-										//Adds support for User Fields
-										global $pmpro_user_fields;
-										foreach( $pmpro_user_fields as $group ) {
-											foreach( $group as $field ) {
-												if ( ! pmpro_is_field( $field ) ) {
+										// Display User fields.
+										if ( class_exists( 'PMPro_Field_Group' ) ) {
+											$field_groups = PMPro_Field_Group::get_all();
+											foreach ( $field_groups as $field_group ) {
+												$fields_to_display = $field_group->get_fields_to_display(
+													array(
+														'scope' => 'checkout',
+													)
+												);
+
+												if ( empty( $fields_to_display ) ) {
 													continue;
 												}
 
-												if ( ! pmpro_check_field_for_level( $field ) ) {
-													continue;
+												foreach ( $fields_to_display as $field ) {
+													$field->display();
 												}
-
-												if( ! isset( $field->profile ) || $field->profile !== 'only' && $field->profile !== 'only_admin' ) {
-													if ( ! empty( $field->required ) ) {
-														$field->showrequired = 'label';
-													} else {
-														$field->showrequired = '';
+											}
+										} else {
+											// Legacy support for displaying User Fields.
+											global $pmpro_user_fields;
+											foreach( $pmpro_user_fields as $group ) {
+												foreach( $group as $field ) {
+													if ( ! pmpro_is_field( $field ) ) {
+														continue;
 													}
-													$field->displayAtCheckout();
+
+													if ( ! pmpro_check_field_for_level( $field ) ) {
+														continue;
+													}
+
+													if( ! isset( $field->profile ) || $field->profile !== 'only' && $field->profile !== 'only_admin' ) {
+														if ( ! empty( $field->required ) ) {
+															$field->showrequired = 'label';
+														} else {
+															$field->showrequired = '';
+														}
+														$field->displayAtCheckout();
+													}
 												}
 											}
 										}

--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -405,61 +405,64 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 								<?php if( !empty( $custom_fields ) ) { do_action( 'pmpro_signup_form_before_submit' ); } ?>
 
 								<?php
-									if ( class_exists( 'PMPro_Field_Group' ) ) {
-										// Loop through all the field groups.
-										$field_groups = PMPro_Field_Group::get_all();
-										foreach ( $field_groups as $field_group ) {
-											// Get the fields to display.
-											$fields_to_display = $field_group->get_fields_to_display(
-												array(
-													'scope' => 'checkout',
-												)
-											);
+									if( ! empty( $custom_fields ) ) {
+										// Adds support for User Fields.
+										if ( class_exists( 'PMPro_Field_Group' ) ) {
+											// Loop through all the field groups.
+											$field_groups = PMPro_Field_Group::get_all();
+											foreach ( $field_groups as $field_group ) {
+												// Get the fields to display.
+												$fields_to_display = $field_group->get_fields_to_display(
+													array(
+														'scope' => 'checkout',
+													)
+												);
 
-											if ( empty( $fields_to_display ) ) {
-												continue;
-											}
+												if ( empty( $fields_to_display ) ) {
+													continue;
+												}
 
-											foreach ( $fields_to_display as $field ) {
-												// Display the field label, if it should be shown.
-												if ( ! empty( $field->showmainlabel ) ) { ?>
-													<label for="<?php echo esc_attr( $field->name ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
-														<?php echo wp_kses_post( $field->label ); ?>
-														<?php
-														// Show an asterisk if the field is required.
-														if ( ! empty( $field->required ) && ! empty( $field->showrequired ) ) {
-															?>
-															<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"><abbr title="<?php echo esc_attr__( 'Required Field', 'pmpro-signup-shortcode' ); ?>">*</abbr></span>
+												foreach ( $fields_to_display as $field ) {
+													// Display the field label, if it should be shown.
+													if ( ! empty( $field->showmainlabel ) ) { ?>
+														<label for="<?php echo esc_attr( $field->name ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+															<?php echo wp_kses_post( $field->label ); ?>
 															<?php
-														}
-														?>
-													</label>															
-													<?php
-												}
-												// Display the field.
-												$field->display();
-											}
-										}
-									} else {
-										// Legacy support for displaying User Fields on PMPro < 3.4.
-										global $pmpro_user_fields;
-										foreach( $pmpro_user_fields as $group ) {
-											foreach( $group as $field ) {
-												if ( ! pmpro_is_field( $field ) ) {
-													continue;
-												}
-
-												if ( ! pmpro_check_field_for_level( $field ) ) {
-													continue;
-												}
-
-												if( ! isset( $field->profile ) || $field->profile !== 'only' && $field->profile !== 'only_admin' ) {
-													if ( ! empty( $field->required ) ) {
-														$field->showrequired = 'label';
-													} else {
-														$field->showrequired = '';
+															// Show an asterisk if the field is required.
+															if ( ! empty( $field->required ) && ! empty( $field->showrequired ) ) {
+																?>
+																<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"><abbr title="<?php echo esc_attr__( 'Required Field', 'pmpro-signup-shortcode' ); ?>">*</abbr></span>
+																<?php
+															}
+															?>
+														</label>															
+														<?php
 													}
-													$field->displayAtCheckout();
+													// Display the field.
+													$field->display();
+												}
+											}
+										} else {
+											// Legacy support for displaying User Fields on PMPro < 3.4.
+											global $pmpro_user_fields;
+											foreach( $pmpro_user_fields as $group ) {
+												foreach( $group as $field ) {
+													if ( ! pmpro_is_field( $field ) ) {
+														continue;
+													}
+
+													if ( ! pmpro_check_field_for_level( $field ) ) {
+														continue;
+													}
+
+													if( ! isset( $field->profile ) || $field->profile !== 'only' && $field->profile !== 'only_admin' ) {
+														if ( ! empty( $field->required ) ) {
+															$field->showrequired = 'label';
+														} else {
+															$field->showrequired = '';
+														}
+														$field->displayAtCheckout();
+													}
 												}
 											}
 										}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-signup-shortcode/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-signup-shortcode/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Using PMPro_Field_Group::display() instead of PMPro_Field::displayAtCheckout on newer PMPro versions.

Resolves #62 

### How to test the changes in this Pull Request:

1. Enable WP_DEBUG display or log.
2. Navigate to the frontend signup shortcode page.
3. Observe that no warnings are displayed/logged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed a PHP warning on sites running PMPro 3.4+ 
