### PR TITLE
Fix no error messaging

### DIFF
--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -285,6 +285,15 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 					overflow: hidden
 				}
 			</style>
+			// Use messaging from PMPro Checkout Page       
+			<?php if($pmpro_msg) { ?>
+				<div role="alert" id="pmpro_message" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message ' . $pmpro_msgt, $pmpro_msgt ) ); ?>">
+					<?php echo wp_kses_post( apply_filters( 'pmpro_checkout_message', $pmpro_msg, $pmpro_msgt ) ); ?>
+				</div>
+			<?php } else { ?>
+				<div id="pmpro_message" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message' ) ); ?>" style="display: none;"></div>
+			<?php } ?>
+			      
 			<?php
 				// Build the selectors for the form based on shortcode attributes.
 				$classes = array();

--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -285,8 +285,9 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 					overflow: hidden
 				}
 			</style>
-			// Use messaging from PMPro Checkout Page       
+			      
 			<?php if($pmpro_msg) { ?>
+			// Use messaging from PMPro Checkout Page 
 				<div role="alert" id="pmpro_message" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message ' . $pmpro_msgt, $pmpro_msgt ) ); ?>">
 					<?php echo wp_kses_post( apply_filters( 'pmpro_checkout_message', $pmpro_msg, $pmpro_msgt ) ); ?>
 				</div>

--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -285,9 +285,8 @@ function pmprosus_signup_shortcode($atts, $content=null, $code="")
 					overflow: hidden
 				}
 			</style>
-			      
-			<?php if($pmpro_msg) { ?>
-			// Use messaging from PMPro Checkout Page 
+			<?php // Use messaging from PMPro Checkout Page  ?>      
+			<?php if($pmpro_msg) { ?>		
 				<div role="alert" id="pmpro_message" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message ' . $pmpro_msgt, $pmpro_msgt ) ); ?>">
 					<?php echo wp_kses_post( apply_filters( 'pmpro_checkout_message', $pmpro_msg, $pmpro_msgt ) ); ?>
 				</div>

--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -3,8 +3,8 @@
  * Plugin Name: Paid Memberships Pro - Signup Shortcode Add On
  * Plugin URI: https://www.paidmembershipspro.com/add-ons/pmpro-signup-shortcode/
  * Description: Embed signup forms anywhere on your WordPress site. Designed to simplify membership registration, especially for free levels.
- * Version: 0.4
- * Author: Paid Memberships Pro
+ * Version: 0.401
+ * Author: Paid Memberships Pro 
  * Author URI: https://www.paidmembershipspro.com
  * Text Domain: pmpro-signup-shortcode
  * Domain Path: /languages


### PR DESCRIPTION
### All Submissions:

* [ X] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-signup-shortcode/blob/dev/.github/CONTRIBUTING.md)?
* [X ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-signup-shortcode/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves [ No Error Messaging bug (see  https://github.com/strangerstudios/pmpro-signup-shortcode/issues/64 )  ]
If the signup shortcode plugin is used without this patch, and the user has set the default checkout page to one that uses the shortcode instead of the long-form checkout, then no error messaging will alert users when they try to sign up and make a mistake like using a previously used email address. This is especially perplexing when PMPro is used in a multisite environment. 

### How to test the changes in this Pull Request:

1.  Set the default checkout page under Memberships/Settings/Pages to the Signup ShortCode Demo page
2.  Open the site in an incognito window and signup
3.  Open a new incognito window and signup with the same email you just used
4.  If the fix worked, you should now see an error message showing that the email address has already been used.  

### Other information:

* [X ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
