### PR TITLE
Resolve checkout level so level-restricted field groups show on signup form

### DIFF
--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -184,6 +184,9 @@ function pmprosus_signup_shortcode( $atts, $content=null, $code="" ) {
 	// If there is a current level in global, save it to a backup variable.
 	$pmpro_level_backup = $pmpro_level;
 
+	// Back up any level in the request so we can restore it after rendering.
+	$pmpro_request_level_backup = isset( $_REQUEST['pmpro_level'] ) ? $_REQUEST['pmpro_level'] : null;
+
 	// Filters the $title value to allow either dynamic or static titles. Note: Returns string if it's a string.
 	$title_display = filter_var( $title, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
 	$login = filter_var( $login, FILTER_VALIDATE_BOOLEAN );
@@ -552,6 +555,13 @@ function pmprosus_signup_shortcode( $atts, $content=null, $code="" ) {
 
 	// Set the global level back to the correct object.
 	$pmpro_level = $pmpro_level_backup;
+
+	// Restore the level request param so code running after this shortcode sees the original request.
+	if ( null === $pmpro_request_level_backup ) {
+		unset( $_REQUEST['pmpro_level'] );
+	} else {
+		$_REQUEST['pmpro_level'] = $pmpro_request_level_backup;
+	}
 
 	return $temp_content;
 }

--- a/pmpro-signup-shortcode.php
+++ b/pmpro-signup-shortcode.php
@@ -269,6 +269,12 @@ function pmprosus_signup_shortcode( $atts, $content=null, $code="" ) {
 	// Set the level for this signup shortcode so level-specific checkout fields appear. Get the first level if no level is specified to use.
 	if ( ! empty( $level ) ) {
 		$pmpro_level = pmpro_getLevel( $level );
+
+		// Populate the level request param so pmpro_getLevelAtCheckout() resolves to this level.
+		// Restricted user-field groups are filtered against that level (PMPro_Field_Group::get_fields_to_display()),
+		// which ignores the $pmpro_level global. Without this, the signup page has no level in the request and falls
+		// back to the default/lowest level, so level-restricted field groups would not display.
+		$_REQUEST['pmpro_level'] = (int) $level;
 	}
 
 	// Get field values from URL or user.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-signup-shortcode/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-signup-shortcode/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When the Signup Shortcode renders a form for a level, User Field groups that are restricted to that level were not appearing, even though they appear on the level's normal checkout page.

The cause is that PMPro resolves which field groups to display via `pmpro_getLevelAtCheckout()` (used by `PMPro_Field_Group::get_fields_to_display()` and the legacy `pmpro_checkout_boxes_fields()`). That function ignores the `$pmpro_level` global the shortcode sets and instead reads the level from the request — `$_REQUEST['pmpro_level']`, then the legacy `$_REQUEST['level']`, then the post's default-level meta, then the lowest level ID.

On a signup shortcode page, there is no level in the request, so it fell back to the default/lowest level and any group restricted to a different level was filtered out.

This PR populates `$_REQUEST['pmpro_level']` with the shortcode's level before the `pmpro_checkout_preheader` and field hooks fire, so field group resolution matches the rest of the form (hidden level input, title, cost). ~~It is set in single level mode only; multi level mode already disables `custom_fields`.~~ 

The `$_REQUEST['pmpro_level']` param is set whenever the shortcode has a resolved level: the specified level in single level mode, or the default-selected level in multi level mode (where it has no practical effect on fields, since multi level mode disables custom_fields).


### How to test the changes in this Pull Request:
1. Under _Memberships > Settings > User Fields_, create a field group with one or more fields and restrict it to a specific level that is not the lowest/default level.
2. Place `[pmpro_signup level="X"]` on a page, where `X` is that restricted level, and view the page — the restricted group's fields now appear.
3. Place `[pmpro_signup level="Y"]` for a different level `Y` and confirm the group does not appear (the restriction is still enforced, not always-on).
4. Submit the form and confirm the field values save correctly to the member.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fixed level-restricted User Field groups not displaying on signup forms.